### PR TITLE
Test default branch locking 2

### DIFF
--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  check_branch:
+  branch-target-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check merge is allowed

--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -4,6 +4,7 @@ name: branch-target-check
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check_branch:

--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -1,0 +1,16 @@
+# Referenced from: https://stackoverflow.com/a/75414339
+
+name: branch-target-check
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check merge is allowed
+        if: github.base_ref == 'master' && github.head_ref != 'development'
+        run: |
+          echo "ERROR: You can only merge to the master branch from the development branch."
+          exit 1


### PR DESCRIPTION
Tests whether the locking the default branch works for PRs opened before the lock was introduced, e.g. without the workflow file.

Update: switched target branch