### PR TITLE
Add workflow file to lock the default branch

### DIFF
--- a/.github/workflows/base-branch-check.yml
+++ b/.github/workflows/base-branch-check.yml
@@ -1,0 +1,24 @@
+# Referenced from: https://stackoverflow.com/a/75414339
+
+name: base-branch-check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - unlocked
+      - enqueued
+      - ready_for_review
+
+jobs:
+  base-branch-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check merge is allowed
+        if: github.base_ref == github.event.repository.default_branch && github.head_ref != 'development'
+        run: |
+          echo "ERROR: You can only merge to the default branch from the development branch."
+          exit 1


### PR DESCRIPTION
Prevents merge from any branches other than 'development'